### PR TITLE
Fix Ruby 2.7 warnings

### DIFF
--- a/georama.gemspec
+++ b/georama.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "semvergen", "~> 1.3"
-  spec.add_development_dependency "bundler", "~> 1"
+  spec.add_development_dependency "bundler", ">= 1"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "guard-rspec", "~> 4.0"
   spec.add_development_dependency "pry"

--- a/lib/georama/url.rb
+++ b/lib/georama/url.rb
@@ -4,7 +4,7 @@ module Georama
 
     def initialize(url)
       raise ArgumentError, "Expected a valid maps url, got nil" if url.nil?
-      @url_string = URI.encode(url)
+      @url_string = URI.encode_www_form_component(url)
       raise ArgumentError, "Not a valid url" unless Georama::Parser.is_valid_url?(@url_string)
       raise ArgumentError, "Not a valid maps url" unless Georama::Parser.is_google_maps_url?(@url_string)
       @parsed_url = URI.parse(@url_string)
@@ -36,7 +36,7 @@ module Georama
 
     def place
       return nil unless type == :place
-      @place ||= URI.unescape(path_components[2].gsub("+", " "))
+      @place ||= URI.decode_www_form_component(path_components[2])
     end
 
     private

--- a/lib/georama/url.rb
+++ b/lib/georama/url.rb
@@ -4,7 +4,7 @@ module Georama
 
     def initialize(url)
       raise ArgumentError, "Expected a valid maps url, got nil" if url.nil?
-      @url_string = escape_url(url)
+      @url_string = encode(url)
       raise ArgumentError, "Not a valid url" unless Georama::Parser.is_valid_url?(@url_string)
       raise ArgumentError, "Not a valid maps url" unless Georama::Parser.is_google_maps_url?(@url_string)
       @parsed_url = URI.parse(@url_string)
@@ -54,7 +54,7 @@ module Georama
       @path_components ||= @parsed_url.path.split("/")[1..-1]
     end
 
-    def escape_url(url)
+    def encode(url)
       uri = URI(url)
       uri.query = URI.encode_www_form_component(uri.query)
       uri.to_s

--- a/lib/georama/url.rb
+++ b/lib/georama/url.rb
@@ -4,7 +4,7 @@ module Georama
 
     def initialize(url)
       raise ArgumentError, "Expected a valid maps url, got nil" if url.nil?
-      @url_string = URI.encode_www_form_component(url)
+      @url_string = escape_url(url)
       raise ArgumentError, "Not a valid url" unless Georama::Parser.is_valid_url?(@url_string)
       raise ArgumentError, "Not a valid maps url" unless Georama::Parser.is_google_maps_url?(@url_string)
       @parsed_url = URI.parse(@url_string)
@@ -52,6 +52,12 @@ module Georama
 
     def path_components
       @path_components ||= @parsed_url.path.split("/")[1..-1]
+    end
+
+    def escape_url(url)
+      uri = URI(url)
+      uri.query = URI.encode_www_form_component(uri.query)
+      uri.to_s
     end
 
   end


### PR DESCRIPTION
Getting rid of warnings ⚠️ 
- `url.rb:7: warning: URI.escape is obsolet`
- `url.rb:39: warning: URI.unescape is obsolete`

Support using bundler 2 :tada: